### PR TITLE
feat: scan-out endpoint, category cascade delete with activity log, earliest_expiration for sort

### DIFF
--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -111,26 +111,53 @@ const categoriesController = {
   },
 
   async deleteCategory(req, res) {
+    const categoryId = parseCategoryId(req.params.id);
+
+    if (!categoryId) {
+      return res.status(400).json({ error: 'Invalid category id' });
+    }
+
+    const client = await pgPool.connect();
     try {
-      const categoryId = parseCategoryId(req.params.id);
+      await client.query('BEGIN');
 
-      if (!categoryId) {
-        return res.status(400).json({ error: 'Invalid category id' });
-      }
-
-      const { rows } = await pgPool.query(
-        `DELETE FROM categories
-         WHERE id = $1
-         RETURNING id`,
+      const { rows: itemRows } = await client.query(
+        `SELECT i.id, i.name, COALESCE(SUM(b.quantity), 0)::int AS total_quantity
+         FROM items i
+         LEFT JOIN item_batches b ON b.item_id = i.id
+         WHERE i.category_id = $1
+         GROUP BY i.id, i.name`,
         [categoryId]
       );
 
-      if (rows.length === 0) {
+      for (const item of itemRows) {
+        if (item.total_quantity > 0) {
+          await client.query(
+            `INSERT INTO activity_log (item_id, item_name, action, quantity)
+             VALUES (NULL, $1, 'removed', $2)`,
+            [item.name, item.total_quantity]
+          );
+        }
+      }
+
+      await client.query(`DELETE FROM items WHERE category_id = $1`, [
+        categoryId,
+      ]);
+
+      const { rows: deletedCategory } = await client.query(
+        `DELETE FROM categories WHERE id = $1 RETURNING id`,
+        [categoryId]
+      );
+
+      if (deletedCategory.length === 0) {
+        await client.query('ROLLBACK');
         return res.status(404).json({ error: 'Category not found' });
       }
 
+      await client.query('COMMIT');
       res.status(200).json({ message: 'Category deleted successfully' });
     } catch (error) {
+      await client.query('ROLLBACK');
       console.error('Delete category error:', error);
       if (error.code === '23503') {
         return res.status(409).json({
@@ -138,6 +165,8 @@ const categoriesController = {
         });
       }
       res.status(500).json({ error: 'Internal server error' });
+    } finally {
+      client.release();
     }
   },
 };

--- a/src/controllers/inventoryController.js
+++ b/src/controllers/inventoryController.js
@@ -1,5 +1,6 @@
 import {
   checkInInventoryItem,
+  checkOutInventoryItem,
   createCategory,
   getCategoriesWithItems,
   getItemDetailById,
@@ -164,6 +165,80 @@ const inventoryController = {
       if (error.code === '23503') {
         return res.status(400).json({ error: 'categoryId does not exist' });
       }
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  },
+
+  async checkOut(req, res) {
+    try {
+      const { barcode, itemId, quantity } = req.body;
+
+      const normalizedQuantity = parsePositiveInteger(quantity, null);
+      if (normalizedQuantity === null) {
+        return res
+          .status(400)
+          .json({ error: 'quantity must be a positive integer' });
+      }
+
+      const hasBarcode =
+        typeof barcode === 'string' && barcode.trim().length > 0;
+      const normalizedItemId =
+        itemId === undefined || itemId === null || itemId === ''
+          ? null
+          : parsePositiveInteger(itemId, null);
+      if (itemId !== undefined && itemId !== null && itemId !== '' && normalizedItemId === null) {
+        return res
+          .status(400)
+          .json({ error: 'itemId must be a positive integer' });
+      }
+
+      if (!hasBarcode && normalizedItemId === null) {
+        return res
+          .status(400)
+          .json({ error: 'barcode or itemId is required' });
+      }
+
+      let result;
+      try {
+        result = await checkOutInventoryItem({
+          barcode: hasBarcode ? barcode.trim() : null,
+          itemId: normalizedItemId,
+          quantity: normalizedQuantity,
+        });
+      } catch (error) {
+        if (error.code === 'BARCODE_NOT_FOUND') {
+          return res.status(404).json({
+            error: 'No item is registered for this barcode',
+            code: 'BARCODE_NOT_FOUND',
+            barcode: error.barcode,
+          });
+        }
+        if (error.code === 'ITEM_NOT_FOUND') {
+          return res
+            .status(404)
+            .json({ error: 'Item not found', code: 'ITEM_NOT_FOUND' });
+        }
+        if (error.code === 'INSUFFICIENT_STOCK') {
+          return res.status(409).json({
+            error: 'Insufficient stock for the requested quantity',
+            code: 'INSUFFICIENT_STOCK',
+            requested: error.requested,
+            available: error.available,
+          });
+        }
+        throw error;
+      }
+
+      const itemDetail = await getItemDetailById(result.item.id);
+
+      res.status(200).json({
+        message: 'Inventory item checked out successfully',
+        item: itemDetail,
+        removed: result.removed,
+        batchesAffected: result.batchesAffected,
+      });
+    } catch (error) {
+      console.error('Inventory check-out error:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
   },

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -16,6 +16,9 @@ const ITEM_SELECT = `
     i.created_at,
     c.name AS category_name,
     COALESCE(SUM(b.quantity), 0)::int AS total_quantity,
+    MIN(b.expiration_date) FILTER (
+      WHERE b.quantity > 0 AND b.expiration_date IS NOT NULL
+    ) AS earliest_expiration,
     CASE
       WHEN COALESCE(SUM(b.quantity), 0) = 0                        THEN 'out_of_stock'
       WHEN COALESCE(SUM(b.quantity), 0) <= i.low_stock_threshold   THEN 'low_stock'

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -10,6 +10,7 @@ const ITEM_SELECT = `
   SELECT
     i.id,
     i.name,
+    i.barcode,
     i.category_id,
     i.low_stock_threshold,
     i.created_at,

--- a/src/middleware/authMiddleware.js
+++ b/src/middleware/authMiddleware.js
@@ -30,4 +30,13 @@ const authMiddleware = async (req, res, next) => {
   }
 };
 
+// Volunteers sign in anonymously; any other Firebase sign-in provider counts
+// as an owner under the existing role model. Use after authMiddleware.
+export const requireOwner = (req, res, next) => {
+  if (req.user?.firebase?.sign_in_provider === 'anonymous') {
+    return res.status(403).json({ error: 'Owner access required' });
+  }
+  next();
+};
+
 export default authMiddleware;

--- a/src/repositories/inventoryRepository.js
+++ b/src/repositories/inventoryRepository.js
@@ -289,3 +289,113 @@ export const checkInInventoryItem = async ({
     client.release();
   }
 };
+
+export const checkOutInventoryItem = async ({ barcode, itemId, quantity }) => {
+  const client = await pgPool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    let itemRow;
+    if (itemId) {
+      const result = await client.query(
+        `SELECT id, name FROM items WHERE id = $1 LIMIT 1;`,
+        [itemId]
+      );
+      itemRow = result.rows[0];
+      if (!itemRow) {
+        const err = new Error('Item not found');
+        err.code = 'ITEM_NOT_FOUND';
+        throw err;
+      }
+    } else {
+      const result = await client.query(
+        `SELECT id, name FROM items WHERE barcode = $1 LIMIT 1;`,
+        [barcode]
+      );
+      itemRow = result.rows[0];
+      if (!itemRow) {
+        const err = new Error('No item registered for this barcode');
+        err.code = 'BARCODE_NOT_FOUND';
+        err.barcode = barcode;
+        throw err;
+      }
+    }
+
+    // FOR UPDATE locks the matched batch rows for the duration of this
+    // transaction so a concurrent checkout cannot read the same stock and
+    // double-decrement it.
+    const batchesResult = await client.query(
+      `SELECT id, expiration_date, quantity
+         FROM item_batches
+        WHERE item_id = $1
+        ORDER BY expiration_date ASC NULLS LAST, id ASC
+        FOR UPDATE;`,
+      [itemRow.id]
+    );
+
+    const available = batchesResult.rows.reduce(
+      (sum, row) => sum + Number(row.quantity),
+      0
+    );
+
+    if (available < quantity) {
+      const err = new Error('Insufficient stock');
+      err.code = 'INSUFFICIENT_STOCK';
+      err.requested = quantity;
+      err.available = available;
+      throw err;
+    }
+
+    let remaining = quantity;
+    const batchesAffected = [];
+
+    for (const batch of batchesResult.rows) {
+      if (remaining === 0) break;
+
+      const batchQty = Number(batch.quantity);
+      if (batchQty === 0) continue;
+
+      const take = Math.min(batchQty, remaining);
+      const newQty = batchQty - take;
+      remaining -= take;
+
+      if (newQty === 0) {
+        await client.query(`DELETE FROM item_batches WHERE id = $1;`, [
+          batch.id,
+        ]);
+      } else {
+        await client.query(
+          `UPDATE item_batches SET quantity = $1 WHERE id = $2;`,
+          [newQty, batch.id]
+        );
+      }
+
+      batchesAffected.push({
+        id: batch.id,
+        expiration_date: batch.expiration_date,
+        quantity_removed: take,
+        remaining: newQty,
+      });
+    }
+
+    await client.query(
+      `INSERT INTO activity_log (item_id, item_name, action, quantity)
+       VALUES ($1, $2, 'removed', $3);`,
+      [itemRow.id, itemRow.name, quantity]
+    );
+
+    await client.query('COMMIT');
+
+    return {
+      item: itemRow,
+      removed: quantity,
+      batchesAffected,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};

--- a/src/routes/inventoryRoutes.js
+++ b/src/routes/inventoryRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import inventoryController from '../controllers/inventoryController.js';
+import authMiddleware, { requireOwner } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
@@ -8,5 +9,11 @@ router.get('/categories', inventoryController.listCategories);
 router.post('/categories', inventoryController.createCategory);
 router.get('/items/:itemId', inventoryController.getItemDetail);
 router.post('/check-in', inventoryController.checkIn);
+router.post(
+  '/check-out',
+  authMiddleware,
+  requireOwner,
+  inventoryController.checkOut
+);
 
 export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -53,6 +53,8 @@ app.use('/auth', authRoutes);
 app.use('/categories', categoriesRoutes);
 app.use('/items', itemRoutes);
 app.use('/activity', activityRoutes);
+app.use('/api/inventory', inventoryRoutes);
+app.use('/api/barcode', barcodeRoutes);
 
 app.get('/health', (req, res) => {
   res.status(200).json({ status: 'ok' });


### PR DESCRIPTION
### Scan Out endpoint
- New owner-only checkout endpoint
- FIFO deduction across batches, earliest expiration first
- Wrapped in a transaction with row-level batch locks to keep concurrent owners safe
- Writes one activity log row per checkout

### Category deletion
- Now wrapped in a transaction
- Deletes items and their batches inside the category instead of leaving them orphaned
- Writes one activity log row per item that had stock

### Items sort support
- Adds earliest_expiration aggregate to the items list and detail responses
- Powers the frontend's new Expiration Dates sort option