### PR TITLE
hotfix: post-merge fixups (server crash + scan-out barcode + duplicate column)

### DIFF
--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -114,25 +114,10 @@ const categoriesController = {
     const client = await pgPool.connect();
 
     try {
-      await client.query('BEGIN');
+      const categoryId = parseCategoryId(req.params.id);
 
-      const { rows: itemRows } = await client.query(
-        `SELECT i.id, i.name, COALESCE(SUM(b.quantity), 0)::int AS total_quantity
-         FROM items i
-         LEFT JOIN item_batches b ON b.item_id = i.id
-         WHERE i.category_id = $1
-         GROUP BY i.id, i.name`,
-        [categoryId]
-      );
-
-      for (const item of itemRows) {
-        if (item.total_quantity > 0) {
-          await client.query(
-            `INSERT INTO activity_log (item_id, item_name, action, quantity)
-             VALUES (NULL, $1, 'removed', $2)`,
-            [item.name, item.total_quantity]
-          );
-        }
+      if (!categoryId) {
+        return res.status(400).json({ error: 'Invalid category id' });
       }
 
       await client.query('BEGIN');

--- a/src/controllers/itemController.js
+++ b/src/controllers/itemController.js
@@ -17,7 +17,6 @@ const ITEM_SELECT = `
       LIMIT 1
     ) AS barcode,
     i.name,
-    i.barcode,
     i.category_id,
     i.low_stock_threshold,
     i.created_at,

--- a/src/repositories/inventoryRepository.js
+++ b/src/repositories/inventoryRepository.js
@@ -360,7 +360,11 @@ export const checkOutInventoryItem = async ({ barcode, itemId, quantity }) => {
       }
     } else {
       const result = await client.query(
-        `SELECT id, name FROM items WHERE barcode = $1 LIMIT 1;`,
+        `SELECT i.id, i.name
+           FROM items i
+           INNER JOIN item_barcodes ib ON ib.item_id = i.id
+          WHERE ib.barcode = $1
+          LIMIT 1;`,
         [barcode]
       );
       itemRow = result.rows[0];


### PR DESCRIPTION
**Three fixes after PR #17 merged. The merge crashed the server and broke two scan-out related queries.

## Fixes

1. **`fix(categories)`**: GitHub web-editor conflict resolution stacked both my and Cameron's `deleteCategory` instead of picking one — duplicate `const itemRows`, double `BEGIN`, missing `parseCategoryId`. Server couldn't start. Restored `categories.js` to `7afa8e5` (Cameron's working version, the agreed resolution).

2. **`fix(scan-out)`**: `/api/inventory/check-out` looked up barcodes via `items.barcode`, which PR #15 stopped populating. Now joins through `item_barcodes`, mirroring `checkInInventoryItem`.

3. **`fix(items)`**: `ITEM_SELECT` had two `barcode` columns (Cameron's subquery alias + my leftover `i.barcode`). pg-driver's last-wins mapping made every item return `barcode: null`. Dropped the duplicate.

## Verification

`node --check` passes on all three files. `categories.js` pre-fix failed to parse under ESM; post-fix is clean. No other call sites affected.

## Known unrelated issue

`createItem` still spreads `RETURNING *` and exposes legacy `items.barcode`. Pre-existing from PR #15, not in scope here.**